### PR TITLE
Fix preservation of unreleased changelogs

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -491,11 +491,13 @@ impl Command for ReleaseWorkflowApplyVersionsCommand {
             info!("computing new versions based on `rc` commit request data");
         }
 
+        let rel_info = sess.repo.get_latest_release_info()?;
+
         sess.apply_versions(&rci)?;
         let mut changes = sess.rewrite()?;
 
         if !dev_mode {
-            sess.apply_changelogs(&rci, &mut changes)?;
+            sess.apply_changelogs(rel_info.commit, &rci, &mut changes)?;
         }
 
         Ok(0)


### PR DESCRIPTION
We had a bug that when you released a subset of the projects in a monorepo, the changelogs of the unreleased packages were lost on the release branch. This was happening because the new release tree was being created from the `rc` tree, which is derived from `master` with modified changelogs for the updated projects. Because we just clobber the release branch with the new tree, this meant that the final `release` changelogs for *non*-updated projects come from `master`, where they are typically placeholders.

I don't want to get into the game of modifying the tree that's ultimately preserved in `release`, and it's pretty convenient to be able to check for changelog modification on `rc` to decide what's being released or not. So, my solution is to update unreleased changelogs in `cranko release-workflow apply-versions` from the `release` branch. That will increase the apparent diff at this stage, but it's generally happening in an automated context anyway.