### PR TITLE
Have `cranko stage` honor `--force` in the intuitive way

### DIFF
--- a/book/src/commands/dev/stage.md
+++ b/book/src/commands/dev/stage.md
@@ -11,6 +11,11 @@ cranko stage [--force] [PROJECT-NAMES...]
 If `{PROJECT-NAMES}` is unspecified, all projects that have been affected by any
 commits since their last release are staged.
 
+Using the `--force` flag and explicit `{PROJECT-NAMES}` will allow you to stage
+projects even if Cranko believes that they have not been affected by any commits
+since their most recent releases. This can be useful if, say, you need to
+re-attempt a release with updated CI configuration but no code changes.
+
 For each project that is staged, its changelog files in the working directory
 are rewritten to include template release-request information and a draft set of
 release notes based on the Git commits affecting the project since its last

--- a/src/main.rs
+++ b/src/main.rs
@@ -728,7 +728,11 @@ impl Command for StageCommand {
                 continue;
             }
 
-            if history.n_commits() == 0 {
+            // We selected this project but don't stage it if:
+            // - there are no new commits AND EITHER
+            //   - we're not in force-mode OR
+            //   - we only selected it because we're in "no-specific-names" mode
+            if (no_names || !self.force) && history.n_commits() == 0 {
                 if !no_names {
                     warn!("no changes detected for project {}", proj.user_facing_name);
                 }


### PR DESCRIPTION
By default, we don't allow you to stage projects if Cranko doesn't think that they've been affected by any commits since their last release. Update `cranko stage` to allow you to do this if the `--force` flag has been supplied and you've explictly named the project.