### PR TITLE
Fix up .NET dev versions and write up some more docs on internal deps

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -15,6 +15,7 @@
 # Reference Material
 
 - [Concepts]()
+  - [Internal Dependencies](concepts/internal-dependencies.md)
   - [Projects](concepts/projects.md)
   - [Releases](concepts/releases.md)
   - [Versions](concepts/versions.md)

--- a/book/src/commands/cicd/npm-lerna-workaround.md
+++ b/book/src/commands/cicd/npm-lerna-workaround.md
@@ -16,8 +16,9 @@ This command will rewrite the `package.json` files of your NPM projects.
 
 #### Example
 
-The [Lerna] tool is somewhat limited in its understanding of internal
-dependencies within a repository. If projects A and B are both at version 0.3,
+The [Lerna] tool is somewhat limited in its understanding of [internal
+dependencies](../../concepts/internal-dependencies.md) within a repository. If
+projects A and B are both at version 0.3,
 and project B states a requirement on version 0.3 of project A, Lerna
 understands the dependency. However, if project B only requires version 0.2 of
 project A, Lerna won't realize that the interdependency is internal. This will

--- a/book/src/commands/dev/confirm.md
+++ b/book/src/commands/dev/confirm.md
@@ -13,7 +13,8 @@ to `cranko stage` and synthesizes it into a new commit on the `rc` branch.
 Edited changelog files in the working directory are then reset to match the HEAD
 commit.
 
-The `cranko confirm` command analyzes the internal interdependencies of the
+The `cranko confirm` command analyzes the
+[internal interdependencies](../../concepts/internal-dependencies.md) of the
 projects within the repository and will refuse to propose a release with
 unsatisfied requirements. That is, if a proposed new release of project X would
 require a new release of project Y but one is not being requested, the command

--- a/book/src/commands/util/show.md
+++ b/book/src/commands/util/show.md
@@ -63,7 +63,8 @@ thiscommit:2021-06-03:NmEuWn3
 ## `cranko show toposort`
 
 This command prints out the names of the projects in the repository, one per
-line, in topologically-sorted order according to internal dependencies. That is,
+line, in topologically-sorted order according to
+[internal dependencies](../../concepts/internal-dependencies.md). That is,
 the name of a project is only printed after the names of all of its dependencies
 in the repo have already been printed. Because dependency cycles are prohibited,
 this is always possible. The exact ordering may not be stable, even from one

--- a/book/src/concepts/internal-dependencies.md
+++ b/book/src/concepts/internal-dependencies.md
@@ -1,0 +1,102 @@
+# Internal Dependencies
+
+An *internal dependency* is a dependency between two [projects](./projects.md)
+stored in the same repository. Internal dependencies are therefore closely
+associated with [monorepos] in Cranko's terminology. You can have a monorepo
+that doesn't have any internal dependencies, but usually the point of a monorepo
+setup is to manage a group of interdependent projects.
+
+[monorepos]: https://en.wikipedia.org/wiki/Monorepo
+
+As outlined in the introduction to [Just-in-Time Versioning][jitv-int-deps],
+internal dependencies (perhaps counterintuitively) take some extra effort to
+manage. This situation stems from two assumptions in the JIT model:
+
+[jitv-int-deps]: ../jit-versioning/index.md#the-monorepo-wrinkle
+
+- Any intra-project dependency (internal or external) needs to be associated
+  with a *version requirement* specifying the range of versions of the
+  "dependee" package that the "depending" package is compatible with. In simple
+  cases this might be expressible as "anything newer than 1.0", but version
+  requirements can potentially be complex ("anything in the 1.x or 2.x series,
+  but not 3.x, and not 1.10").
+- In the JIT versioning model, specific version numbers shouldn't be stored in
+  the main development branch of your repository.
+
+It's important to note that dependency version requirements can't be determined
+automatically. Say that I have a monorepo containing two projects,
+`awesome_database` and `awesome_webserver`. It's reasonable to assume that at
+any given commit, the two are compatible, but is the development version of
+`awesome_webserver` compatible with version 1.9 of `awesome_database`? Is it
+compatible with version 1.1? You could imagine some level of automated API
+analysis to test source-level compatibility, but it's always possible that the
+semantics of an API can change in a way that maintains source compatibility but
+breaks actual usage. Ultimately the *only* sound approach is for a human to make
+this determination.
+
+Getting back to Cranko's challenge: at some point I'm going to want to make a
+new release of `awesome_webserver` with metadata saying that it requires
+`awesome_database >= 2.0`. How can I tell Cranko what version requirement to
+insert into the `awesome_webserver` project files when the main development
+branch can't "know" what the most recent version of `awesome_database` is?
+
+## Commit-Based Internal Dependency Version Requirements
+
+Cranko solves this problem by requiring that you specify internal dependency
+version requirements as *Git commits*, not version numbers. For each internal
+dependency from a "depending" project X on a "dependee" project Y, you must
+specify a Git commit such that X is compatible with releases of Y whose sources
+contain that commit in their histories.
+
+What does Cranko do with this information? When making a release of project X,
+Cranko has sufficient information to determine the *oldest* version of project Y
+containing that commit. It will rewrite project X's public metadata to encode
+that version requirement.
+
+It can happen that no such release exists — perhaps project X requires a new
+feature that was just added to Y, and no release of Y has yet been made. Cranko
+will detect this situation and, correctly, refuse to let you make a release of
+project X. However, you can release X and Y *simultaneously* (in one `rc` push),
+and Cranko will detect this and generate correct metadata.
+
+The commit-based model implies a restriction that version requirements for
+internal dependencies must have the simplest form: X is compatible with any
+version of Y newer than Z, for some Z determined at release time. This is not
+expected to be restrictive in practice because Cranko assumes that at any given
+commit in a monorepo, all projects are compatible as expressed in the source
+tree.
+
+## Expressing Internal Dependency Commit Requirements
+
+Project meta-files don't have native support for commit-based version
+requirements because it would be inappropriate to include information specific
+to a project's revision system in such files. Therefore, Cranko always has to
+define some kind of custom way for you to capture this metadata, with the
+specific mechanism depending on the project type. For instance:
+
+- In Rust, you add `[package.metadata.internal_dep_versions]` fields in Cargo.toml
+- In Python, you annotate version requirement lines in your `setup.py` file or
+  equivalent
+
+The documentation for each language integration should specify the approach and
+specific syntax you should use.
+
+## Development with Internal Dependency Requirements
+
+The [`cranko bootstrap`][bs] command will endeavor to update your project files
+to include your pre-existing internal version requirements using a special
+"manual" mode. This is required for version requirements that reach into a
+project's pre-Cranko history.
+
+[bs]: ../workflows-bootstrap/index.md#transforming-internal-dependencies
+
+Once the internal requirements are set up, you should *ideally* update commit
+requirements as APIs are added or broken. For instance, say that project
+`awesome_database` adds a new API in commit A, and project `awesome_webserver`
+starts using it sometime later in commit B. Commit B *should* update the
+metadata to indicate that `awesome_webserver` now requires a version of
+`awesome_database` based on commit A, or later.
+
+If you don't remember to update the metadata immediately, that's OK. So long as
+the metadata for `awesome_webserver` are updated sometime before its next
+release, the released files will contain the right information.

--- a/book/src/concepts/versions.md
+++ b/book/src/concepts/versions.md
@@ -46,7 +46,7 @@ Used by Cargo and NPM packages.
 
 .NET versions emulate the .NET [System.Version][sysver] type. This is a simple
 type following the form `MAJOR.MINOR.BUILD.REVISION`, where each piece is an
-integer.
+integer. The maximum allowed value of each item is 65534.
 
 [sysver]: https://docs.microsoft.com/en-us/dotnet/api/system.version
 

--- a/book/src/integrations/csproj.md
+++ b/book/src/integrations/csproj.md
@@ -38,9 +38,9 @@ When updating project files, both the `AssemblyVersion` and the
 
 ## Internal Dependencies
 
-“Internal” dependencies refer to [monorepo] situations where one repository
-contains more than one project, and some of those projects depend on one
-another.
+[“Internal” dependencies](../concepts/internal-dependencies.md) refer to
+[monorepo] situations where one repository contains more than one project, and
+some of those projects depend on one another.
 
 [monorepo]: https://en.wikipedia.org/wiki/Monorepo
 

--- a/book/src/integrations/python.md
+++ b/book/src/integrations/python.md
@@ -114,9 +114,9 @@ annotated_files = [
 
 ## Internal Dependencies
 
-“Internal” dependencies refer to [monorepo] situations where one repository
-contains more than one project, and some of those projects depend on one
-another.
+[“Internal” dependencies](../concepts/internal-dependencies.md) refer to
+[monorepo] situations where one repository contains more than one project, and
+some of those projects depend on one another.
 
 [monorepo]: https://en.wikipedia.org/wiki/Monorepo
 

--- a/book/src/workflows-bootstrap/index.md
+++ b/book/src/workflows-bootstrap/index.md
@@ -79,8 +79,9 @@ basis for assigning new version numbers.
 
 If your repository contains more than one project, some of those projects
 probably depend on each other. With zeroed-out version numbers, it is not
-generally possible to express the version constraints of those internal
-dependencies in existing metadata formats. For instance, before bootstrapping,
+generally possible to express the version constraints of those [internal
+dependencies](../concepts/internal-dependencies.md) in existing metadata
+formats. For instance, before bootstrapping,
 you might have had a package `foo_cli` that depends on `foo_lib >= 1.3`: it
 works if linked against `foo_lib` version 1.3.0, but not if linked against
 `foo_lib` version 1.2.17. That didn’t stop being true just because the version

--- a/src/version.rs
+++ b/src/version.rs
@@ -184,10 +184,11 @@ impl VersionBumpScheme {
                 }
 
                 Version::DotNet(v) => {
-                    let num = 10000 * (local.year() as usize)
-                        + 100 * (local.month() as usize)
-                        + (local.day() as usize);
-                    v.revision = num as i32;
+                    // We can't use a human-readable date-code because version
+                    // terms have a maximum value of 65534, so we use a number
+                    // that's about the number of days since 1970. That should
+                    // take us to about the year 2149.
+                    v.revision = (local.timestamp() / 86400) as i32;
                 }
             }
 
@@ -316,7 +317,8 @@ mod dotnet {
     /// A version compatible with .NET's System.Version
     ///
     /// These versions are simple: they have the form
-    /// `{major}.{minor}.{build}.{revision}`.
+    /// `{major}.{minor}.{build}.{revision}`. Each term must be between 0 and
+    /// 65534.
     #[derive(Clone, Debug, Default, Eq, Ord, PartialEq, PartialOrd)]
     pub struct DotNetVersion {
         pub major: i32,


### PR DESCRIPTION
Looks like .NET version terms can only go up to 65534: [link](https://stackoverflow.com/questions/44679828/reserved-max-value-in-the-net-assembly-version).