### PR TITLE
Fix vdproj rewriting: can't use all four version terms

### DIFF
--- a/book/src/integrations/csproj.md
+++ b/book/src/integrations/csproj.md
@@ -41,6 +41,11 @@ System.Version](../concepts/versions.md#net-versions) type.
 When updating project files, both the `AssemblyVersion` and the
 `AssemblyFileVersion` attributes are updated, if present.
 
+If a project has one or more associated `.vdproj` installer projects, the
+`ProductVersion` stored with the installer(s) will lose the fourth component
+(the "revision") of the project version, because four-component versions are
+rejected by the installer builder.
+
 
 ## Internal Dependencies
 

--- a/src/csproj.rs
+++ b/src/csproj.rs
@@ -546,9 +546,15 @@ impl Rewriter for VdprojRewriter {
                 );
 
                 let line = if line.contains("\"ProductVersion\" =") {
+                    // ProductVersion must have the form `X.Y.Z`; the "revision"
+                    // component must be stripped.
+                    let prod_vers = proj.version.to_string();
+                    let pieces: Vec<_> = prod_vers.split('.').collect();
+                    let prod_vers = &pieces[..3].join(".");
+
                     did_anything = true;
                     atry!(
-                        replace_vdproj_text(&line, &proj.version.to_string());
+                        replace_vdproj_text(&line, prod_vers);
                         ["couldn't rewrite version-string source line `{}`", line]
                     )
                 } else {


### PR DESCRIPTION
There's always something to fix ...