### PR TITLE
csproj: rewrite ProductCode and PackageCode when rewriting version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -258,6 +258,7 @@ dependencies = [
  "thiserror",
  "toml",
  "toml_edit",
+ "uuid",
  "zip",
 ]
 
@@ -1730,6 +1731,15 @@ dependencies = [
  "idna",
  "matches",
  "percent-encoding",
+]
+
+[[package]]
+name = "uuid"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ textwrap = "^0.12"
 thiserror = "1.0"
 toml = "^0.5"
 toml_edit = "^0.2"
+uuid = { version = "^0.8", features = ["v4"] }
 zip = { version = "^0.5", default-features = false, features = ["deflate", "time"] }
 
 [features]

--- a/book/src/integrations/csproj.md
+++ b/book/src/integrations/csproj.md
@@ -44,7 +44,14 @@ When updating project files, both the `AssemblyVersion` and the
 If a project has one or more associated `.vdproj` installer projects, the
 `ProductVersion` stored with the installer(s) will lose the fourth component
 (the "revision") of the project version, because four-component versions are
-rejected by the installer builder.
+rejected by the installer builder. The `PackageCode` and `ProductCode` of the
+installer will be replaced with a new, randomly-generated UUID (the same one for
+both codes). This is a conservative, and possibly sketchy, approach, since it
+means that different installer versions will unconditionally be treated as
+["major upgrades"]. See [Changing the Product Code][ctpc] for more information.
+
+["major upgrades"]: https://docs.microsoft.com/en-us/windows/win32/msi/major-upgrades
+[ctpc]: https://docs.microsoft.com/en-us/windows/win32/msi/changing-the-product-code
 
 
 ## Internal Dependencies


### PR DESCRIPTION
We were doing this at least somewhat incorrectly: the docs state that no two installers should have the same PackageCode unless they're identical. The ProductCode has more sophisticated semantics that we could and probably should support, but I'm trying to get my installers working and am going to pile up some technical debt here.