### PR TITLE
Add the ability to ignore autodetected projects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,9 +39,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.52"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84450d0b4a8bd1ba4144ce8ce718fbc5d071358b1e5384bace6536b3d1f2d5b3"
+checksum = "4361135be9122e0870de935d7c439aef945b9f9ddd4199a553b5270b49c82a27"
 
 [[package]]
 name = "arrayvec"
@@ -73,9 +73,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "base64"
@@ -97,9 +97,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bumpalo"
-version = "3.8.0"
+version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f1e260c3a9040a7c19a12468758f4c16f31a81a1fe087482be9570ec864bb6c"
+checksum = "a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899"
 
 [[package]]
 name = "byteorder"
@@ -133,9 +133,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.72"
+version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
+checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
 dependencies = [
  "jobserver",
 ]
@@ -191,9 +191,9 @@ dependencies = [
 
 [[package]]
 name = "combine"
-version = "4.6.2"
+version = "4.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2b2f5d0ee456f3928812dfc8c6d9a1d592b98678f6d56db9b0cd2b7bc6c8db5"
+checksum = "50b727aacc797f9fc28e355d21f34709ac4fc9adecfe470ad07b8f4464f53062"
 dependencies = [
  "bytes 1.1.0",
  "memchr",
@@ -207,9 +207,9 @@ checksum = "fe1d7dcda7d1da79e444bdfba1465f2f849a58b07774e1df473ee77030cb47a7"
 
 [[package]]
 name = "core-foundation"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6888e10551bb93e424d8df1d07f1a8b4fceb0001a3a4b048bfc47554946f47b3"
+checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -244,7 +244,7 @@ dependencies = [
  "nom",
  "petgraph",
  "quick-xml",
- "rand 0.8.4",
+ "rand 0.8.5",
  "reqwest",
  "semver",
  "serde",
@@ -264,9 +264,9 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.3.0"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "738c290dfaea84fc1ca15ad9c168d083b05a714e1efddd8edaab678dc28d2836"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -282,9 +282,9 @@ dependencies = [
 
 [[package]]
 name = "dirs-sys"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03d86534ed367a67548dc68113a0f5db55432fdfbb6e6f9d77704397d95d5780"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
 dependencies = [
  "libc",
  "redox_users",
@@ -325,11 +325,20 @@ dependencies = [
 
 [[package]]
 name = "erased-serde"
-version = "0.3.17"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44a5d80251b806a14cd3e4e1a582e912d5cbf6904ab19fdefbd7a56adca088e1"
+checksum = "ad132dd8d0d0b546348d7d86cb3191aad14b34e5f979781fc005c80d4ac67ffd"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "fastrand"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
+dependencies = [
+ "instant",
 ]
 
 [[package]]
@@ -423,42 +432,42 @@ checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
 name = "futures-channel"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3dda0b6588335f360afc675d0564c17a77a2bda81ca178a4b6081bd86c7f0b"
+checksum = "c3083ce4b914124575708913bca19bfe887522d6e2e6d0952943f5eac4a74010"
 dependencies = [
  "futures-core",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0c8ff0461b82559810cdccfde3215c3f373807f5e5232b71479bff7bb2583d7"
+checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
 
 [[package]]
 name = "futures-io"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f9d34af5a1aac6fb380f735fe510746c38067c5bf16c7fd250280503c971b2"
+checksum = "fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b"
 
 [[package]]
 name = "futures-sink"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3055baccb68d74ff6480350f8d6eb8fcfa3aa11bdc1a1ae3afdd0514617d508"
+checksum = "21163e139fa306126e6eedaf49ecdb4588f939600f0b1e770f4205ee4b7fa868"
 
 [[package]]
 name = "futures-task"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ee7c6485c30167ce4dfb83ac568a849fe53274c831081476ee13e0dce1aad72"
+checksum = "57c66a976bf5909d801bbef33416c41372779507e7a6b3a5e25e4749c58f776a"
 
 [[package]]
 name = "futures-util"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b5cf40b47a271f77a8b1bec03ca09044d99d2372c0de244e66430761127164"
+checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
 dependencies = [
  "futures-core",
  "futures-io",
@@ -471,9 +480,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.3"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
+checksum = "9be70c98951c83b8d2f8f60d7065fa6d5146873094452a1008da8c2f1e4205ad"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
@@ -579,9 +588,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.5.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acd94fdbe1d4ff688b67b04eee2e17bd50995534a61539e45adfefb45e5e5503"
+checksum = "9100414882e15fb7feccb4897e5f0ff0ff1ca7d1a86a23208ada4d7a18e6c6c4"
 
 [[package]]
 name = "httpdate"
@@ -639,12 +648,21 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.7.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
+checksum = "0f647032dfaa1f8b6dc29bd3edb7bbef4861b8b8007ebb118d6db284fd59f6ee"
 dependencies = [
  "autocfg",
  "hashbrown",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -658,9 +676,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.3.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f2d64f2edebec4ce84ad108148e67e1064789bee435edc5b60ad398714a3a9"
+checksum = "35e70ee094dc02fd9c13fdad4940090f22dbd6ac7c9e7094a46cf0232a50bc7c"
 
 [[package]]
 name = "itoa"
@@ -685,9 +703,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.55"
+version = "0.3.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cc9ffccd38c451a86bf13657df244e9c3f37493cce8e5e21e940963777acc84"
+checksum = "a38fc24e30fd564ce974c02bf1d337caddff65be6cc4735a1f7eab22a7440f04"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -729,9 +747,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.112"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
+checksum = "efaa7b300f3b5fe8eb6bf21ce3895e1751d9665086af2d64b42f19701015ff4f"
 
 [[package]]
 name = "libgit2-sys"
@@ -763,9 +781,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.3"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de5435b8549c16d423ed0c03dbaafe57cf6c3344744f1242520d59c9d8ecec66"
+checksum = "6f35facd4a5673cb5a48822be2be1d4236c1c99cb4113cab7061ac720d5bf859"
 dependencies = [
  "cc",
  "libc",
@@ -781,9 +799,9 @@ checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 
 [[package]]
 name = "log"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
+checksum = "6389c490849ff5bc16be905ae24bc913a9c8892e19b2341dbc175e14c341c2b8"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -817,9 +835,9 @@ checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
 name = "mime_guess"
-version = "2.0.3"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2684d4c2e97d99848d30b324b00c8fcc7e5c897b7cbb5819b09e7c90e8baf212"
+checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
 dependencies = [
  "mime",
  "unicase",
@@ -868,9 +886,9 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.8"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48ba9f7719b5a0f42f338907614285fb5fd70e53858141f69898a1fb7203b24d"
+checksum = "fd7e2f3618557f980e0b17e8856252eee3c97fa12c54dff0ca290fb6266ca4a9"
 dependencies = [
  "lazy_static",
  "libc",
@@ -950,9 +968,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
+checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
 
 [[package]]
 name = "openssl"
@@ -970,15 +988,15 @@ dependencies = [
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "111.17.0+1.1.1m"
+version = "111.18.0+1.1.1n"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05d6a336abd10814198f66e2a91ccd7336611f30334119ca8ce300536666fcf4"
+checksum = "7897a926e1e8d00219127dc020130eca4292e5ca666dd592480d72c3eca2ff6c"
 dependencies = [
  "cc",
 ]
@@ -1053,9 +1071,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58893f751c9b0412871a09abd62ecd2a00298c6c83befa223ef98c52aef40cbe"
+checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
 name = "ppv-lite86"
@@ -1107,9 +1125,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.14"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47aa80447ce4daf1717500037052af176af5d38cc3e571d9ec1c7353fc10c87d"
+checksum = "632d02bff7f874a36f33ea8bb416cd484b90cc66c1194b1a1110d067a7013f58"
 dependencies = [
  "proc-macro2",
 ]
@@ -1129,14 +1147,13 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
  "rand_core 0.6.3",
- "rand_hc",
 ]
 
 [[package]]
@@ -1174,15 +1191,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_hc"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
-dependencies = [
- "rand_core 0.6.3",
-]
-
-[[package]]
 name = "rdrand"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1193,28 +1201,29 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.10"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
+checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "redox_users"
-version = "0.4.0"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
+checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
  "getrandom",
  "redox_syscall",
+ "thiserror",
 ]
 
 [[package]]
 name = "regex"
-version = "1.5.4"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1289,9 +1298,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.4.2"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525bc1abfda2e1998d152c45cf13e696f76d0a4972310b22fac1658b05df7c87"
+checksum = "2dc14f172faf8a0194a3aded622712b0de276821addc574fa54fc0a1167e10dc"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -1302,9 +1311,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.4.2"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9dd14d83160b528b7bfd66439110573efcfbe281b17fc2ca9f39f550d619c7e"
+checksum = "0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1328,18 +1337,18 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.133"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97565067517b60e2d1ea8b268e59ce036de907ac523ad83a0475da04e818989a"
+checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.133"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed201699328568d8d08208fdd080e3ff594e6c422e438b6705905da01005d537"
+checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1348,9 +1357,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.74"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee2bb9cd061c5865d345bb02ca49fcef1391741b672b54a0bf7b679badec3142"
+checksum = "8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95"
 dependencies = [
  "itoa 1.0.1",
  "ryu",
@@ -1359,21 +1368,21 @@ dependencies = [
 
 [[package]]
 name = "serde_urlencoded"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edfa57a7f8d9c1d260a549e7224100f6c43d43f9103e06dd8b4095a9b2b43ce9"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
  "form_urlencoded",
- "itoa 0.4.8",
+ "itoa 1.0.1",
  "ryu",
  "serde",
 ]
 
 [[package]]
 name = "slab"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9def91fd1e018fe007022791f865d0ccc9b3a0d5001e01aabb8b40e46000afb5"
+checksum = "eb703cfe953bccee95685111adeedb76fabe4e97549a58d16f03ea7b9367bb32"
 
 [[package]]
 name = "socket2"
@@ -1400,9 +1409,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "structopt"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40b9788f4202aa75c240ecc9c15c65185e6a39ccdeb0fd5d008b98825464c87c"
+checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
 dependencies = [
  "clap",
  "lazy_static",
@@ -1442,9 +1451,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.84"
+version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecb2e6da8ee5eb9a61068762a32fa9619cc591ceb055b3687f4cd4051ec2e06b"
+checksum = "704df27628939572cd88d33f171cd6f896f4eaca85252c6e0a72d8d8287ee86f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1480,13 +1489,13 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
 dependencies = [
  "cfg-if 1.0.0",
+ "fastrand",
  "libc",
- "rand 0.8.4",
  "redox_syscall",
  "remove_dir_all",
  "winapi 0.3.9",
@@ -1494,9 +1503,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
 ]
@@ -1644,9 +1653,9 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.29"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "375a639232caf30edfc78e8d89b2d4c375515393e7af7e16f01cd96917fb2105"
+checksum = "4a1bdf54a7c28a2bbf701e1d2233f6c77f473486b94bee4f9678da5a148dca7f"
 dependencies = [
  "cfg-if 1.0.0",
  "log",
@@ -1656,9 +1665,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.21"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4ed65637b8390770814083d20756f87bfa2c21bf2f110babdc5438351746e4"
+checksum = "90442985ee2f57c9e1b548ee72ae842f4a9a20e3f417cc38dbc5dc684d9bb4ee"
 dependencies = [
  "lazy_static",
 ]
@@ -1705,9 +1714,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
+checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
 
 [[package]]
 name = "unicode-width"
@@ -1784,9 +1793,9 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "632f73e236b219150ea279196e54e610f5dbafa5d61786303d4da54f84e47fce"
+checksum = "25f1af7423d8588a3d840681122e72e6a24ddbcb3f0ec385cac0d12d24256c06"
 dependencies = [
  "cfg-if 1.0.0",
  "serde",
@@ -1796,9 +1805,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a317bf8f9fba2476b4b2c85ef4c4af8ff39c3c7f0cdfeed4f82c34a880aa837b"
+checksum = "8b21c0df030f5a177f3cba22e9bc4322695ec43e7257d865302900290bcdedca"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -1811,9 +1820,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.28"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e8d7523cb1f2a4c96c1317ca690031b714a51cc14e05f712446691f413f5d39"
+checksum = "2eb6ec270a31b1d3c7e266b999739109abce8b6c87e4b31fcfcd788b65267395"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -1823,9 +1832,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d56146e7c495528bf6587663bea13a8eb588d39b36b679d83972e1a2dbbdacf9"
+checksum = "2f4203d69e40a52ee523b2529a773d5ffc1dc0071801c87b3d270b471b80ed01"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1833,9 +1842,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7803e0eea25835f8abdc585cd3021b3deb11543c6fe226dcd30b228857c5c5ab"
+checksum = "bfa8a30d46208db204854cadbb5d4baf5fcf8071ba5bf48190c3e59937962ebc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1846,15 +1855,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
+checksum = "3d958d035c4438e28c70e4321a2911302f10135ce78a9c7834c0cab4123d06a2"
 
 [[package]]
 name = "web-sys"
-version = "0.3.55"
+version = "0.3.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38eb105f1c59d9eaa6b5cdc92b859d85b926e82cb2e0945cd0c9259faa6fe9fb"
+checksum = "c060b319f29dd25724f09a2ba1418f142f539b2be99fbf4d2d5a8f7330afb8eb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/book/src/configuration/index.md
+++ b/book/src/configuration/index.md
@@ -25,6 +25,8 @@ The `config.toml` file may contain the following items:
   - [`release_name`](#the-release_name-field) — The name of the `release`-like branch
   - [`release_tag_name_format`](#the-release_tag_name_format-field) — The format for release tag names
   - [`upstream_urls`](#the-upstream_urls-field) — How the upstream remote is recognized
+- [`[projects]`](#the-projects-section) — Configuration relating to individual projects
+  - [`ignore`](#the-ignore-field) — Flagging projects to be ignored
 
 As mentioned above, additional items are planned to be added as the need arises.
 
@@ -64,7 +66,7 @@ This field is a list of strings giving the Git URLs associated with the
 canonical upstream repository, which is the one that will perform automated
 release processing upon updates to its `rc`-like branch. For example:
 
-```
+```toml
 upstream_urls = [
   "git@github.com:pkgw/cranko.git",
   "https://github.com/pkgw/cranko.git"
@@ -79,3 +81,29 @@ unspecified), and there is only one remote, Cranko will use it. If there is more
 than one remote but one is named `origin`, Cranko will use that. Otherwise,
 Cranko will error out. If more than one remote matches any of the URLs, one of
 them will be used but it is unspecified which.
+
+### The `[projects]` section
+
+This section contains configuration relating to individual projects in the
+repository. Cranko generallly prefers to locate this configuration in
+project-appropriate metadata files (such as `Cargo.toml`), but this isn't always
+possible.
+
+This “section” should be a dictionary keyed by the full “qualified names”
+associated with a project. For instance, for an NPM project, you might configure
+it with code such as:
+
+```toml
+[projects."npm:@mymonorepo/tests"]
+ignore = true
+```
+
+#### The `ignore` field
+
+This field tells Cranko to ignore the existence of the project in question.
+
+For a variety of reasons, Cranko might autodetect a project in your repository
+that you never intend to release. This setting allows you to pretend that such a
+project simply doesn’t exist. The setting is applied in the repository-wide
+configuration file, not in project metadata, in case the project is imported
+from a vendor source that doesn’t include Cranko metadata.

--- a/src/app.rs
+++ b/src/app.rs
@@ -70,6 +70,8 @@ impl AppBuilder {
             .apply_config(config.repo)
             .with_context(|| "failed to finalize repository setup")?;
 
+        let proj_config = config.projects;
+
         // Now auto-detect everything in the repo index.
 
         if self.populate_graph {
@@ -87,7 +89,7 @@ impl AppBuilder {
                 let (dirname, basename) = p.split_basename();
                 cargo.process_index_item(dirname, basename);
                 csproj.process_index_item(&repo, p, dirname, basename)?;
-                npm.process_index_item(&repo, &mut graph, p, dirname, basename)?;
+                npm.process_index_item(&repo, &mut graph, p, dirname, basename, &proj_config)?;
                 pypa.process_index_item(dirname, basename);
                 Ok(())
             })?;
@@ -96,10 +98,10 @@ impl AppBuilder {
             self.graph = graph;
             // End dumb hack.
 
-            cargo.finalize(&mut self)?;
-            csproj.finalize(&mut self)?;
+            cargo.finalize(&mut self, &proj_config)?;
+            csproj.finalize(&mut self, &proj_config)?;
             npm.finalize(&mut self)?;
-            pypa.finalize(&mut self)?;
+            pypa.finalize(&mut self, &proj_config)?;
         }
 
         // Apply project config and compile the graph.

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -672,7 +672,7 @@ impl BinaryArchiveMode {
         path.push(format!(
             "{}-{}-{}.zip",
             proj.qualified_names()[0],
-            proj.version.to_string(),
+            proj.version,
             target
         ));
 
@@ -732,7 +732,7 @@ impl BinaryArchiveMode {
         path.push(format!(
             "{}-{}-{}.tar.gz",
             proj.qualified_names()[0],
-            proj.version.to_string(),
+            proj.version,
             target
         ));
 

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -154,7 +154,7 @@ impl MarkdownChangelog {
             .map(|prc| sess.repo.get_file_at_commit(&prc, &changelog_repopath))
             .transpose()?
             .flatten()
-            .unwrap_or_else(Vec::new);
+            .unwrap_or_default();
 
         // Start working on rewriting the existing file.
 

--- a/src/pypa.rs
+++ b/src/pypa.rs
@@ -107,7 +107,7 @@ impl PypaLoader {
                     })
                     .transpose()?;
 
-                let data = data.map(|d| d.tool).flatten().map(|t| t.cranko).flatten();
+                let data = data.and_then(|d| d.tool).and_then(|t| t.cranko);
 
                 if let Some(ref data) = data {
                     name = data.name.clone();
@@ -328,8 +328,7 @@ impl PypaLoader {
                 for req_name in &internal_reqs {
                     let req = config
                         .as_ref()
-                        .map(|c| c.internal_dep_versions.get(req_name))
-                        .flatten()
+                        .and_then(|c| c.internal_dep_versions.get(req_name))
                         .map(|text| app.repo.parse_history_ref(text))
                         .transpose()?
                         .map(|cref| app.repo.resolve_history_ref(&cref, &toml_repopath))

--- a/src/pypa.rs
+++ b/src/pypa.rs
@@ -24,6 +24,7 @@ use crate::{
     a_ok_or,
     app::{AppBuilder, AppSession},
     atry,
+    config::ProjectConfiguration,
     errors::{Error, Result},
     graph::GraphQueryBuilder,
     project::{DepRequirement, DependencyTarget, ProjectId},
@@ -49,7 +50,11 @@ impl PypaLoader {
     }
 
     /// Finalize autoloading any PyPA projects. Consumes this object.
-    pub fn finalize(self, app: &mut AppBuilder) -> Result<()> {
+    pub fn finalize(
+        self,
+        app: &mut AppBuilder,
+        pconfig: &HashMap<String, ProjectConfiguration>,
+    ) -> Result<()> {
         if self.dirs_of_interest.len() > 1 {
             warn!("multiple Python projects detected. Internal interdependenciess are not yet supported.")
         }
@@ -275,78 +280,79 @@ impl PypaLoader {
 
             // OMG, we actually have the core info.
 
-            let ident = app.graph.add_project();
+            let qnames = vec![name.clone(), "pypa".to_owned()];
 
-            {
-                let mut proj = app.graph.lookup_mut(ident);
-
-                proj.qnames = vec![name.clone(), "pypa".to_owned()];
-                proj.version = Some(Version::Pep440(version));
-                proj.prefix = Some(dirname.to_owned());
-
-                let mut rw_path = dirname.clone();
-                rw_path.push(main_version_file.as_bytes());
-                let rw = PythonRewriter::new(ident, rw_path);
-                proj.rewriters.push(Box::new(rw));
-            }
-
-            // Handle the other annotated files. Besides registering them for
-            // rewrites, we also scan them now to detect additional metadata. In
-            // particular, dependencies on non-Python projects.
-
-            let mut internal_reqs = HashSet::new();
-
-            for path in config
-                .as_ref()
-                .map(|c| &c.annotated_files[..])
-                .unwrap_or(&[])
-            {
-                let mut rw_path = dirname.clone();
-                rw_path.push(path.as_bytes());
-
-                atry!(
-                    scan_rewritten_file(app, &rw_path, &mut internal_reqs);
-                    ["in Python project {}, could not scan the `annotated_files` entry {}",
-                     dir_desc, rw_path.escaped()]
-                );
-
-                let rw = PythonRewriter::new(ident, rw_path);
+            if let Some(ident) = app.graph.try_add_project(qnames, pconfig) {
                 {
-                    let proj = app.graph.lookup_mut(ident);
+                    let mut proj = app.graph.lookup_mut(ident);
+
+                    proj.version = Some(Version::Pep440(version));
+                    proj.prefix = Some(dirname.to_owned());
+
+                    let mut rw_path = dirname.clone();
+                    rw_path.push(main_version_file.as_bytes());
+                    let rw = PythonRewriter::new(ident, rw_path);
                     proj.rewriters.push(Box::new(rw));
                 }
-            }
 
-            // Now that we have *all* of the internal requirements, register them with
-            // the graph.
+                // Handle the other annotated files. Besides registering them for
+                // rewrites, we also scan them now to detect additional metadata. In
+                // particular, dependencies on non-Python projects.
 
-            for req_name in &internal_reqs {
-                let req = config
+                let mut internal_reqs = HashSet::new();
+
+                for path in config
                     .as_ref()
-                    .map(|c| c.internal_dep_versions.get(req_name))
-                    .flatten()
-                    .map(|text| app.repo.parse_history_ref(text))
-                    .transpose()?
-                    .map(|cref| app.repo.resolve_history_ref(&cref, &toml_repopath))
-                    .transpose()?;
+                    .map(|c| &c.annotated_files[..])
+                    .unwrap_or(&[])
+                {
+                    let mut rw_path = dirname.clone();
+                    rw_path.push(path.as_bytes());
 
-                if req.is_none() {
-                    warn!(
-                        "missing or invalid key `tool.cranko.internal_dep_versions.{}` in `{}`",
-                        &req_name,
-                        toml_repopath.escaped()
+                    atry!(
+                        scan_rewritten_file(app, &rw_path, &mut internal_reqs);
+                        ["in Python project {}, could not scan the `annotated_files` entry {}",
+                        dir_desc, rw_path.escaped()]
                     );
-                    warn!("... this is needed to specify the oldest version of `{}` compatible with `{}`",
-                        &req_name, &name);
+
+                    let rw = PythonRewriter::new(ident, rw_path);
+                    {
+                        let proj = app.graph.lookup_mut(ident);
+                        proj.rewriters.push(Box::new(rw));
+                    }
                 }
 
-                let req = req.unwrap_or(DepRequirement::Unavailable);
-                app.graph.add_dependency(
-                    ident,
-                    DependencyTarget::Text(req_name.clone()),
-                    "(unavailable)".to_owned(),
-                    req,
-                )
+                // Now that we have *all* of the internal requirements, register them with
+                // the graph.
+
+                for req_name in &internal_reqs {
+                    let req = config
+                        .as_ref()
+                        .map(|c| c.internal_dep_versions.get(req_name))
+                        .flatten()
+                        .map(|text| app.repo.parse_history_ref(text))
+                        .transpose()?
+                        .map(|cref| app.repo.resolve_history_ref(&cref, &toml_repopath))
+                        .transpose()?;
+
+                    if req.is_none() {
+                        warn!(
+                            "missing or invalid key `tool.cranko.internal_dep_versions.{}` in `{}`",
+                            &req_name,
+                            toml_repopath.escaped()
+                        );
+                        warn!("... this is needed to specify the oldest version of `{}` compatible with `{}`",
+                            &req_name, &name);
+                    }
+
+                    let req = req.unwrap_or(DepRequirement::Unavailable);
+                    app.graph.add_dependency(
+                        ident,
+                        DependencyTarget::Text(req_name.clone()),
+                        "(unavailable)".to_owned(),
+                        req,
+                    )
+                }
             }
         }
 

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -1787,7 +1787,7 @@ pub fn escape_pathlike(b: &[u8]) -> String {
         s.to_owned()
     } else {
         let mut buf = vec![b'\"'];
-        buf.extend(b.iter().map(|c| std::ascii::escape_default(*c)).flatten());
+        buf.extend(b.iter().flat_map(|c| std::ascii::escape_default(*c)));
         buf.push(b'\"');
         String::from_utf8(buf).unwrap()
     }

--- a/src/version.rs
+++ b/src/version.rs
@@ -907,7 +907,7 @@ mod pep440 {
             fn to_owned(&self) -> Pep440Version {
                 Pep440Version {
                     epoch: self.0,
-                    segments: self.1.iter().copied().collect(),
+                    segments: self.1.to_vec(),
                     pre_release: self.2,
                     post_release: self.3,
                     dev_release: self.4,


### PR DESCRIPTION
Done with central configuration based on qnames, which seems like the most robust way to do things. This way if you vendor in some code you can control the Cranko-ification without needing to modify the vendored files.