### PR TITLE
Fix release checks

### DIFF
--- a/ci/zenodo.json5
+++ b/ci/zenodo.json5
@@ -3,7 +3,7 @@
 // remarks in this file.
 
 {
-  conceptrecid: 'new-for:0.12.0',
+  conceptrecid: 'new-for:0.12.1',
 
   metadata: {
     upload_type: 'software',

--- a/src/zenodo.rs
+++ b/src/zenodo.rs
@@ -718,7 +718,7 @@ pub struct PublishCommand {
 impl Command for PublishCommand {
     fn execute(self) -> Result<i32> {
         let sess = AppSession::initialize_default()?;
-        let (dev_mode, _rci) = sess.ensure_ci_rc_mode(self.force)?;
+        let (dev_mode, _rel_info) = sess.ensure_ci_release_mode()?;
 
         if dev_mode {
             if self.force {
@@ -808,7 +808,7 @@ pub struct UploadArtifactsCommand {
 impl Command for UploadArtifactsCommand {
     fn execute(self) -> Result<i32> {
         let sess = AppSession::initialize_default()?;
-        let (dev_mode, _rci) = sess.ensure_ci_rc_mode(self.force)?;
+        let (dev_mode, _rel_info) = sess.ensure_ci_release_mode()?;
 
         if dev_mode {
             if self.force {


### PR DESCRIPTION
`zenodo upload-artifacts` and `zenodo publish` should require that they be run in "release" mode, not "rc" mode.