### PR TITLE
More stuff to get Zenodo working

### DIFF
--- a/book/src/commands/cicd/zenodo-preregister.md
+++ b/book/src/commands/cicd/zenodo-preregister.md
@@ -38,17 +38,19 @@ metadata file used by this command.
 [zint]: ../../integrations/zenodo.md
 [zconfig]: ../../configuration/zenodo.md
 
-This command requires that the environment variable `ZENODO_TOKEN` has been set
-to a Zenodo API token, *except during pull request processing*. During pull
-request processing, you should make sure **not** to provide this parameter, so
-that it is not accessible to malicious submissions.
-
 This command can be run during pull requests, not just during formal releases.
 In that case, fake DOIs will be used for the rewrite steps. These are guaranteed
 to start with the text `"xx.xxxx/"`, unlike real DOIs which always start with
 `10.`. The DOIs should be obviously fake to any user that sees them, but if you
 have code that embeds or outputs those DOIs, you may wish to add tests that
 check for these fake values and issue warnings as appropriate.
+
+This command requires that the environment variable `ZENODO_TOKEN` has been set
+to a Zenodo API token, *during release processing only*. During pull request
+processing, you should make sure **not** to provide this parameter, so that it
+is not accessible to malicious submissions. As a precaution, in the latter
+circumstance, the command will exit with an error if the environment variable is
+non-empty.
 
 #### See also
 

--- a/book/src/integrations/zenodo.md
+++ b/book/src/integrations/zenodo.md
@@ -88,11 +88,13 @@ While you should see the [Zenodo Metadata Files][zmeta] page for the full
 details of the file format, the short version is that it has two main fields.
 The first, `"metadata"`, contains the metadata that will describe your Zenodo
 deposition. See [the Zenodo developer documentation][mdformat] for a precise
-definition of all of the fields that can be used here. *The contents here are
-things you need to decide for yourself,* including, most importantly, the author
-list that you want to associate with your project.
+definition of all of the fields that can be used here, or check out [Cranko’s
+own version of the file][cmetafile] for inspiration. *The contents of this file
+are things you need to decide for yourself,* including, most importantly, the
+author list that you want to associate with your project.
 
 [mdformat]: https://developers.zenodo.org/#deposit-metadata
+[cmetafile]: https://github.com/pkgw/cranko/blob/master/ci/zenodo.json5
 
 The second field, `"conceptrecid"`, will be used to ensure that successive
 releases of your project are all tied together with the same concept DOI. When
@@ -130,14 +132,17 @@ This insertion happens during the ['cranko zenodo preregister`][prereg] command,
 which will rewrite any files whose paths you pass to it on the command line.
 The following rewrite rules are followed:
 
+- The text `xx.xxxx/dev-build.$project.version`, where `$project` is the name of
+  the Cranko project being released, is replaced with the version DOI. To be
+  explicit, for Cranko itself the template to be replaced would be
+  `xx.xxxx/dev-build.cranko.version`.
 - The text `xx.xxxx/dev-build.$project.concept`, where `$project` is the name of
   the Cranko project being released, is replaced with the concept DOI.
-- The text `xx.xxxx/dev-build.$project.version`, where `$project` is the name of
-  the Cranko project being released, is replaced with the version DOI.
 
 If you’re feeling extra-clever, you can include these templates in your
 `CHANGELOG.md` entry, and your final changelog will include the DOIs of the
-release that it describes.
+release that it describes. (If you do this, you’ll need to pass the path to
+`CHANGELOG.md` as an argument to [`cranko zenodo preregister`][prereg].)
 
 If you’re building out of source control, these replacements won't happen, of
 course. If a pull request is being built, fake DOIs with similar forms will be
@@ -156,7 +161,7 @@ to work.
 [zdev]: https://developers.zenodo.org/
 [ztok]: https://zenodo.org/account/settings/applications/tokens/new/
 
-The ['cranko zenodo preregister`][prereg] command(s) should be run at the
+The [`cranko zenodo preregister`][prereg] command(s) should be run at the
 beginning of your CI/CD workflow, before [`cranko release-workflow commit`].
 After it runs, you should `git add` your modified files to make sure they get
 included in the release commit.

--- a/ci/azure-deployment.yml
+++ b/ci/azure-deployment.yml
@@ -85,8 +85,8 @@ jobs:
     - bash: |
         set -xeuo pipefail
         vname="cranko-$(./cranko show version cranko)"
-        git archive --prefix="$vname/" -o cranko-$vname.tar.gz HEAD
-        ./cranko zenodo upload-artifacts --metadata=ci/zenodo.json5 cranko-$vname.tar.gz
+        git archive --prefix="$vname/" -o "$vname.tar.gz" HEAD
+        ./cranko zenodo upload-artifacts --metadata=ci/zenodo.json5 "$vname.tar.gz"
       displayName: Upload source tarball
       env:
         ZENODO_TOKEN: $(ZENODO_TOKEN)

--- a/ci/zenodo.json5
+++ b/ci/zenodo.json5
@@ -1,9 +1,9 @@
 // See https://developers.zenodo.org/#representation for definition of
-// deposition metadata. The documentation there should trusted more than any
+// deposition metadata. The documentation there should be trusted more than any
 // remarks in this file.
 
 {
-  conceptrecid: 'new-for:0.12.1',
+  conceptrecid: 'new-for:0.12.2',
 
   metadata: {
     upload_type: 'software',

--- a/src/zenodo.rs
+++ b/src/zenodo.rs
@@ -45,6 +45,7 @@ impl ZenodoService {
 
         Ok(reqwest::blocking::Client::builder()
             .default_headers(headers)
+            .timeout(None) // default is 30s; Zenodo is slow
             .build()?)
     }
 


### PR DESCRIPTION
My artifact uploads were hitting the 30s timeouts that reqwest has by default, because Zenodo is slow. Local testing indicates that if we just remove the timeouts, things should work.

Some other minor improvements, but that's the big one.