### PR TITLE
zenodo: fix monorepo non-release pathway

### DIFF
--- a/book/src/integrations/zenodo.md
+++ b/book/src/integrations/zenodo.md
@@ -145,10 +145,11 @@ release that it describes. (If you do this, you’ll need to pass the path to
 `CHANGELOG.md` as an argument to [`cranko zenodo preregister`][prereg].)
 
 If you’re building out of source control, these replacements won't happen, of
-course. If a pull request is being built, fake DOIs with similar forms will be
-substituted in. You can add checks in your code to see whether the DOIs start
-with the universal DOI prefix, `"10."`, to know whether your DOIs are real or
-fake.
+course. If a pull request or other non-release build is being processed, or if
+you’re in a monorepo and the package in question isn’t being released, fake DOIs
+with similar forms will be substituted in. You can add checks in your code to
+see whether the DOIs start with the universal DOI prefix, `"10."`, to know
+whether your DOIs are real or fake.
 
 
 ## CI/CD Workflow
@@ -162,15 +163,25 @@ to work.
 [ztok]: https://zenodo.org/account/settings/applications/tokens/new/
 
 The [`cranko zenodo preregister`][prereg] command(s) should be run at the
-beginning of your CI/CD workflow, before [`cranko release-workflow commit`].
-After it runs, you should `git add` your modified files to make sure they get
-included in the release commit.
+beginning of your CI/CD workflow, before [`cranko release-workflow commit`]. As
+described above, the command inserts placeholders for non-release builds, so you
+can run it in all of your workflows without worrying about needing to detect
+whether the current build is for a project release. If you’re using a monorepo
+with multiple projects that get Zenodo deposits, run the command as many times
+as needed. After all invocations are done, you should `git add` your modified
+files to make sure they get included in the release commit.
 
 [`cranko release-workflow commit`]: ./release-workflow-commit.md
 
 At the end of your CI/CD workflow, if you are actually making real releases, you
 should run [`cranko zenodo upload-artifacts`][upload] as needed, then finally
-[`cranko zenodo publish`][publish] to publish your new deposits.
+[`cranko zenodo publish`][publish] to publish your new deposits. Once again, in
+a monorepo scenario, these commands should be run as many times as needed — with
+filters in place to only execute them if the projects in question have actually
+been released. This can be accomplished with [`cranko show if-released
+--exit-code`][csifec].
+
+[csifec]: ../commands/util/show.md#cranko-show-if-released
 
 
 ## Continued Releases

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -31,7 +31,7 @@ pub struct BootstrapProjectInfo {
 }
 
 /// The `bootstrap` commands.
-#[derive(Debug, PartialEq, StructOpt)]
+#[derive(Debug, Eq, PartialEq, StructOpt)]
 pub struct BootstrapCommand {
     #[structopt(
         short = "f",

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -423,7 +423,7 @@ impl Rewriter for CargoRewriter {
 }
 
 /// Cargo-specific CLI utilities.
-#[derive(Debug, PartialEq, StructOpt)]
+#[derive(Debug, Eq, PartialEq, StructOpt)]
 pub enum CargoCommands {
     #[structopt(name = "foreach-released")]
     /// Run a "cargo" command for each released Cargo project.
@@ -434,7 +434,7 @@ pub enum CargoCommands {
     PackageReleasedBinaries(PackageReleasedBinariesCommand),
 }
 
-#[derive(Debug, PartialEq, StructOpt)]
+#[derive(Debug, Eq, PartialEq, StructOpt)]
 pub struct CargoCommand {
     #[structopt(subcommand)]
     command: CargoCommands,
@@ -450,7 +450,7 @@ impl Command for CargoCommand {
 }
 
 /// `cranko cargo foreach-released`
-#[derive(Debug, PartialEq, StructOpt)]
+#[derive(Debug, Eq, PartialEq, StructOpt)]
 pub struct ForeachReleasedCommand {
     #[structopt(
         long = "command-name",
@@ -517,7 +517,7 @@ impl Command for ForeachReleasedCommand {
 }
 
 /// `cranko cargo package-released-binaries`
-#[derive(Debug, PartialEq, StructOpt)]
+#[derive(Debug, Eq, PartialEq, StructOpt)]
 pub struct PackageReleasedBinariesCommand {
     #[structopt(
         long = "command-name",

--- a/src/github.rs
+++ b/src/github.rs
@@ -177,7 +177,7 @@ impl GitHubInformation {
 }
 
 /// The `github` subcommands.
-#[derive(Debug, PartialEq, StructOpt)]
+#[derive(Debug, Eq, PartialEq, StructOpt)]
 pub enum GithubCommands {
     #[structopt(name = "create-custom-release")]
     /// Create a single, customized GitHub release
@@ -204,7 +204,7 @@ pub enum GithubCommands {
     UploadArtifacts(UploadArtifactsCommand),
 }
 
-#[derive(Debug, PartialEq, StructOpt)]
+#[derive(Debug, Eq, PartialEq, StructOpt)]
 pub struct GithubCommand {
     #[structopt(subcommand)]
     command: GithubCommands,
@@ -224,7 +224,7 @@ impl Command for GithubCommand {
 }
 
 /// Create a single custom GitHub release.
-#[derive(Debug, PartialEq, StructOpt)]
+#[derive(Debug, Eq, PartialEq, StructOpt)]
 pub struct CreateCustomReleaseCommand {
     #[structopt(long = "name", help = "The user-facing name for the release")]
     release_name: String,
@@ -267,7 +267,7 @@ impl Command for CreateCustomReleaseCommand {
 }
 
 /// Create new release(s) on GitHub.
-#[derive(Debug, PartialEq, StructOpt)]
+#[derive(Debug, Eq, PartialEq, StructOpt)]
 pub struct CreateReleasesCommand {
     #[structopt(help = "Name(s) of the project(s) to release on GitHub")]
     proj_names: Vec<String>,
@@ -338,7 +338,7 @@ impl Command for CreateReleasesCommand {
 }
 
 /// hidden Git credential helper command
-#[derive(Debug, PartialEq, StructOpt)]
+#[derive(Debug, Eq, PartialEq, StructOpt)]
 pub struct CredentialHelperCommand {
     #[structopt(help = "The operation")]
     operation: String,
@@ -359,7 +359,7 @@ impl Command for CredentialHelperCommand {
 }
 
 /// Delete a release from GitHub.
-#[derive(Debug, PartialEq, StructOpt)]
+#[derive(Debug, Eq, PartialEq, StructOpt)]
 pub struct DeleteReleaseCommand {
     #[structopt(help = "Name of the release's tag on GitHub")]
     tag_name: String,
@@ -380,7 +380,7 @@ impl Command for DeleteReleaseCommand {
 }
 
 /// Install as a Git credential helper
-#[derive(Debug, PartialEq, StructOpt)]
+#[derive(Debug, Eq, PartialEq, StructOpt)]
 pub struct InstallCredentialHelperCommand {}
 
 impl Command for InstallCredentialHelperCommand {
@@ -404,7 +404,7 @@ impl Command for InstallCredentialHelperCommand {
 }
 
 /// Upload one or more artifact files to a GitHub release.
-#[derive(Debug, PartialEq, StructOpt)]
+#[derive(Debug, Eq, PartialEq, StructOpt)]
 pub struct UploadArtifactsCommand {
     #[structopt(
         long = "overwrite",

--- a/src/gitutil.rs
+++ b/src/gitutil.rs
@@ -11,7 +11,7 @@ use super::Command;
 use crate::errors::Result;
 
 /// Force-create an ancestor-less branch containing a directory tree.
-#[derive(Debug, PartialEq, StructOpt)]
+#[derive(Debug, Eq, PartialEq, StructOpt)]
 pub struct RebootBranchCommand {
     #[structopt(
         long = "message",
@@ -69,14 +69,14 @@ impl Command for RebootBranchCommand {
     }
 }
 
-#[derive(Debug, PartialEq, StructOpt)]
+#[derive(Debug, Eq, PartialEq, StructOpt)]
 pub enum GitUtilCommands {
     #[structopt(name = "reboot-branch")]
     /// Force-create an ancestor-less branch
     RebootBranch(RebootBranchCommand),
 }
 
-#[derive(Debug, PartialEq, StructOpt)]
+#[derive(Debug, Eq, PartialEq, StructOpt)]
 pub struct GitUtilCommand {
     #[structopt(subcommand)]
     command: GitUtilCommands,

--- a/src/npm.rs
+++ b/src/npm.rs
@@ -358,7 +358,7 @@ impl Rewriter for PackageJsonRewriter {
 }
 
 /// Npm-specific CLI utilities.
-#[derive(Debug, PartialEq, StructOpt)]
+#[derive(Debug, Eq, PartialEq, StructOpt)]
 pub enum NpmCommands {
     #[structopt(name = "foreach-released")]
     /// Run a command for each released NPM project.
@@ -374,7 +374,7 @@ pub enum NpmCommands {
     LernaWorkaround(LernaWorkaroundCommand),
 }
 
-#[derive(Debug, PartialEq, StructOpt)]
+#[derive(Debug, Eq, PartialEq, StructOpt)]
 pub struct NpmCommand {
     #[structopt(subcommand)]
     command: NpmCommands,
@@ -391,7 +391,7 @@ impl Command for NpmCommand {
 }
 
 /// `cranko npm foreach-released`
-#[derive(Debug, PartialEq, StructOpt)]
+#[derive(Debug, Eq, PartialEq, StructOpt)]
 pub struct ForeachReleasedCommand {
     #[structopt(help = "The command to run", required = true)]
     command: Vec<OsString>,
@@ -453,7 +453,7 @@ impl Command for ForeachReleasedCommand {
 }
 
 /// `cranko npm install-token`
-#[derive(Debug, PartialEq, StructOpt)]
+#[derive(Debug, Eq, PartialEq, StructOpt)]
 pub struct InstallTokenCommand {
     #[structopt(
         long = "registry",
@@ -489,7 +489,7 @@ impl Command for InstallTokenCommand {
 }
 
 /// `cranko npm lerna-workaround`
-#[derive(Debug, PartialEq, StructOpt)]
+#[derive(Debug, Eq, PartialEq, StructOpt)]
 pub struct LernaWorkaroundCommand {}
 
 impl Command for LernaWorkaroundCommand {

--- a/src/pypa.rs
+++ b/src/pypa.rs
@@ -714,7 +714,7 @@ impl Rewriter for PythonRewriter {
 }
 
 /// Python-specific CLI utilities.
-#[derive(Debug, PartialEq, StructOpt)]
+#[derive(Debug, Eq, PartialEq, StructOpt)]
 pub enum PythonCommands {
     #[structopt(name = "foreach-released")]
     /// Run a command for each released PyPA project.
@@ -725,7 +725,7 @@ pub enum PythonCommands {
     InstallToken(InstallTokenCommand),
 }
 
-#[derive(Debug, PartialEq, StructOpt)]
+#[derive(Debug, Eq, PartialEq, StructOpt)]
 pub struct PythonCommand {
     #[structopt(subcommand)]
     command: PythonCommands,
@@ -741,7 +741,7 @@ impl Command for PythonCommand {
 }
 
 /// `cranko python foreach-released`
-#[derive(Debug, PartialEq, StructOpt)]
+#[derive(Debug, Eq, PartialEq, StructOpt)]
 pub struct ForeachReleasedCommand {
     #[structopt(help = "The command to run", required = true)]
     command: Vec<OsString>,
@@ -803,7 +803,7 @@ impl Command for ForeachReleasedCommand {
 }
 
 /// `cranko python install-token`
-#[derive(Debug, PartialEq, StructOpt)]
+#[derive(Debug, Eq, PartialEq, StructOpt)]
 pub struct InstallTokenCommand {
     #[structopt(
         long = "repository",

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -1418,7 +1418,7 @@ impl ChangeList {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct RepoHistory {
     commits: Vec<CommitId>,
     release_commit: Option<CommitId>,

--- a/src/zenodo.rs
+++ b/src/zenodo.rs
@@ -620,7 +620,7 @@ impl ZenodoMetadata {
 }
 
 /// The `zenodo` subcommands.
-#[derive(Debug, PartialEq, StructOpt)]
+#[derive(Debug, Eq, PartialEq, StructOpt)]
 pub enum ZenodoCommands {
     /// Pre-register a deposition, obtaining DOIs and applying them to the source.
     Preregister(PreregisterCommand),
@@ -633,7 +633,7 @@ pub enum ZenodoCommands {
     UploadArtifacts(UploadArtifactsCommand),
 }
 
-#[derive(Debug, PartialEq, StructOpt)]
+#[derive(Debug, Eq, PartialEq, StructOpt)]
 pub struct ZenodoCommand {
     #[structopt(subcommand)]
     command: ZenodoCommands,
@@ -650,7 +650,7 @@ impl Command for ZenodoCommand {
 }
 
 /// Pre-register a deposition, obtaining DOIs and applying them to the source.
-#[derive(Debug, PartialEq, StructOpt)]
+#[derive(Debug, Eq, PartialEq, StructOpt)]
 pub struct PreregisterCommand {
     #[structopt(
         short = "f",
@@ -707,7 +707,7 @@ impl Command for PreregisterCommand {
 }
 
 /// Publish a deposition, registering the DOI(s).
-#[derive(Debug, PartialEq, StructOpt)]
+#[derive(Debug, Eq, PartialEq, StructOpt)]
 pub struct PublishCommand {
     #[structopt(
         short = "f",
@@ -794,7 +794,7 @@ impl Command for PublishCommand {
 }
 
 /// Upload one or more files as artifacts associated with a Zenodo deposit.
-#[derive(Debug, PartialEq, StructOpt)]
+#[derive(Debug, Eq, PartialEq, StructOpt)]
 pub struct UploadArtifactsCommand {
     #[structopt(
         short = "f",


### PR DESCRIPTION
I overlooked something. If you were making a release in a monorepo, and a Zenodo project was *not* being released, the preregister command would error out. But to be consistent with our pull-request workflow -- and generally more helpful -- we should succeed without minting new DOIs. In principle, we should recover the DOIs from the most recent release and use them, which we could do by tracking down the zenodo.json file in the release branch, but we don't have good infrastructure to do that. So instead we just use the existing fake-DOI approach.