### PR TITLE
Work around a bug in which `dynfmt` fails in release mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -368,8 +368,7 @@ dependencies = [
 [[package]]
 name = "dynfmt"
 version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c298552016db86f0d49e5de09818dd86c536f66095013cc415f4f85744033f"
+source = "git+https://github.com/jqnatividad/dynfmt?branch=2021-clippy_ptr_as_ptr-bumpdeps#0dec5eaceba58e294283d8ebc6333b421220c186"
 dependencies = [
  "erased-serde",
  "lazy_static",
@@ -405,9 +404,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "erased-serde"
-version = "0.3.31"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c138974f9d5e7fe373eb04df7cae98833802ae4b11c24ac7039a21d5af4b26c"
+checksum = "4adbf0983fe06bd3a5c19c8477a637c2389feb0994eca7a59e3b961054aa7c0a"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,5 +55,9 @@ zip = { version = "^0.5", default-features = false, features = [
   "time",
 ] }
 
+# https://github.com/jan-auer/dynfmt/pull/9
+[patch.crates-io]
+dynfmt = { git = "https://github.com/jqnatividad/dynfmt", branch = "2021-clippy_ptr_as_ptr-bumpdeps" }
+
 [features]
 vendored-openssl = ["git2/vendored-openssl"]


### PR DESCRIPTION
See: https://github.com/jan-auer/dynfmt/pull/9

And: https://github.com/jqnatividad/qsv/pull/1467/files

This should go away when a new dynfmt release comes out, or at least migrate to a scheme where we're not relying on someone else's repo and branch. But this should be OK for now.