### PR TITLE
Vendor in a ci_info fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,9 +89,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.15.3"
+version = "1.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e84ce723ab67259cfeb9877c6a639ee9eb7a27b28123abd71db7f0d5d0cc9d86"
+checksum = "7b7b6141e96a8c160799cc2d5adecd5cbbe5054cb8c7c4af53da0f83bb7ad256"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -99,9 +99,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.36.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a442ece363113bd4bd4c8b18977a7798dd4d3c3383f34fb61936960e8f4ad8"
+checksum = "5c34dda4df7017c8db52132f0f8a2e0f8161649d15723ed63fc00c82d0f2081a"
 dependencies = [
  "cc",
  "cmake",
@@ -174,9 +174,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.53"
+version = "1.2.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "755d2fce177175ffca841e9a06afdb2c4ab0f593d53b4dee48147dfaade85932"
+checksum = "6354c81bbfd62d9cfa9cb3c773c2b7b2a3a482d569de977fd0e961f6e7c00583"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -301,7 +301,7 @@ dependencies = [
  "ci_info",
  "configparser",
  "dirs",
- "dynfmt",
+ "dynfmt2",
  "flate2",
  "git-url-parse",
  "git2",
@@ -389,15 +389,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
-name = "dynfmt"
-version = "0.1.5"
-source = "git+https://github.com/jqnatividad/dynfmt?branch=2021-clippy_ptr_as_ptr-bumpdeps#0dec5eaceba58e294283d8ebc6333b421220c186"
+name = "dynfmt2"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bde0c22c83ae33ace665d8b1637cb50ef68500d3b9007e87106a636c99cc46b"
 dependencies = [
  "erased-serde",
- "lazy_static",
  "regex",
  "serde",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1409,9 +1409,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.43"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc74d9a594b72ae6656596548f56f667211f8a97b3d4c3d467150794690dc40a"
+checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
 dependencies = [
  "proc-macro2",
 ]
@@ -1838,9 +1838,9 @@ checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
 
 [[package]]
 name = "socket2"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
+checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
 dependencies = [
  "libc",
  "windows-sys 0.60.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,8 +218,7 @@ dependencies = [
 [[package]]
 name = "ci_info"
 version = "0.14.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d502ead02cc105c33a87aa76817cdca915a7576b59caba5eeb4e7abdd633f23"
+source = "git+https://github.com/pkgw/ci_info?branch=github-fix#9b7c628cb40b53ff3298396ec17a05d5c0bdcd3f"
 dependencies = [
  "envmnt",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ zip = { version = "^7", default-features = false, features = [
 
 # https://github.com/jan-auer/dynfmt/pull/9
 [patch.crates-io]
+ci_info = { git = "https://github.com/pkgw/ci_info", branch = "github-fix" }
 dynfmt = { git = "https://github.com/jqnatividad/dynfmt", branch = "2021-clippy_ptr_as_ptr-bumpdeps" }
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ chrono = "^0.4"
 ci_info = "^0.14"
 configparser = "^3.0"
 dirs = "^6"
-dynfmt = { version = "^0.1", default-features = false, features = ["curly"] }
+dynfmt2 = { version = "^0.3", default-features = false, features = ["curly"] }
 flate2 = "^1.0"
 git-url-parse = "^0.4"
 git2 = "^0.20"
@@ -55,10 +55,8 @@ zip = { version = "^7", default-features = false, features = [
   "time",
 ] }
 
-# https://github.com/jan-auer/dynfmt/pull/9
 [patch.crates-io]
 ci_info = { git = "https://github.com/pkgw/ci_info", branch = "github-fix" }
-dynfmt = { git = "https://github.com/jqnatividad/dynfmt", branch = "2021-clippy_ptr_as_ptr-bumpdeps" }
 
 [features]
 vendored-openssl = ["git2/vendored-openssl"]

--- a/book/src/configuration/index.md
+++ b/book/src/configuration/index.md
@@ -54,13 +54,13 @@ This field is a string specifying how the names of Git tags corresponding to
 releases will be constructed. The default is `{project_slug}@{version}`.
 
 Values are interpolated using a standard curly-brace substitution scheme (as
-implemented by the `curly` module of the [dynfmt] crate). Available input
+implemented by the `curly` module of the [dynfmt2] crate). Available input
 variables are:
 
 - `project_slug`: the “user facing name” of the released project
 - `version`: the stringification of the version of the released project
 
-[dynfmt]: https://github.com/jan-auer/dynfmt
+[dynfmt2]: https://github.com/dathere/dynfmt2
 
 #### The `upstream_urls` field
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -164,6 +164,29 @@ impl AppSession {
             let rc_name = self.repo.upstream_rc_name();
             let release_name = self.repo.upstream_release_name();
 
+            // Since we're running in CI, might as well log generously
+            let ci_vendor_desc = self
+                .ci_info
+                .vendor
+                .map(|v| format!("{:?}", v))
+                .unwrap_or_else(|| "Unknown".to_owned());
+            let ci_build_type = maybe_pr
+                .map(|is_pr| {
+                    if is_pr {
+                        "pull request"
+                    } else {
+                        "branch update"
+                    }
+                })
+                .unwrap_or("unknown type");
+            let ci_branch_desc = maybe_ci_branch
+                .map(|b| format!("`{b}`"))
+                .unwrap_or_else(|| "unknown".to_owned());
+
+            info!(
+                "{ci_vendor_desc} CI environment detected, {ci_build_type} build, source branch {ci_branch_desc}"
+            );
+
             if maybe_ci_branch.is_none() {
                 warn!("cannot determine the triggering branch name in this CI environment");
                 warn!("... this will affect many workflow safety checks")

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -9,7 +9,7 @@
 //! release(s). That's exactly the information contained in a release changelog.
 
 use chrono::{offset::Local, Datelike};
-use dynfmt::{Format, SimpleCurlyFormat};
+use dynfmt2::{Format, SimpleCurlyFormat};
 use std::{
     collections::HashMap,
     fs::File,

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -4,7 +4,7 @@
 //! State of the backing version control repository.
 
 use anyhow::{anyhow, bail};
-use dynfmt::{Format, SimpleCurlyFormat};
+use dynfmt2::{Format, SimpleCurlyFormat};
 use log::{info, warn};
 use serde::{Deserialize, Serialize};
 use std::{
@@ -81,7 +81,7 @@ pub struct Repository {
     upstream_release_name: String,
 
     /// The format specification to use for release tag names, as understood by
-    /// the `SimpleCurlyFormat` of the `dynfmt` crate.
+    /// the `SimpleCurlyFormat` of the `dynfmt2` crate.
     release_tag_name_format: String,
 
     /// "Bootstrap" versioning information used to tell us where versions were at


### PR DESCRIPTION
It doesn't get the branch name in GitHub Actions, which is something of an issue.

While we're at it, migrate to dynfmt2 since I was reminded that that's now an option.